### PR TITLE
fixing larm_f parameter

### DIFF
--- a/src/Dust.h
+++ b/src/Dust.h
@@ -70,7 +70,7 @@ class CDustComponent
 
         stochastic_heating_max_size = 0;
         delta0 = 8.28e23 * 2.5e-12 * 1e8 * 1e-6 * 1e6;
-        larm_f = 4.1e-21;
+        larm_f = 4.1e-19;
         aspect_ratio = 0;
         sub_temp = 1e6;
         material_density = 0;

--- a/src/Grid.h
+++ b/src/Grid.h
@@ -350,7 +350,8 @@ class CGridBasic
         max_data = 0;
 
         delta0 = 8.28e23 * 2.5e-12 * 1e8 * 1e-6 * 1e6;
-        larm_f = 4.1e-21;
+        // This would always reset the value to the value given below. I.e. the command "<larm_f> value" in the command file would effectively be ignored, hence it needs to be commented out
+        // larm_f = 4.1e-21;
 
         max_gas_dens = -1e300;
         min_gas_dens = 1e300;

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -48,7 +48,7 @@ class parameters
         max_obs_distance = -1e300;
 
         delta0 = 8.28e23 * 2.5e-12 * 1e8 * 1e-6 * 1e6;
-        larm_f = 4.1e-21;
+        larm_f = 4.1e-19;
 
         nr_of_mc_lvl_pop_photons = 0;
         mc_lvl_pop_seed = 0;


### PR DESCRIPTION
Changed parameter larm_f to the correct value given by Hughes et al. 2009, ApJ, 704, 1024, Eq. 1 (this equation can be re-derived from Lazarian 2007 and Hoang & Lazarian 2009). Here, the prefactor is given in cgs units for B in microGauss, conversion into SI results in 4.1e-19. Additional bug in Grid.h prevented the setting/usage of „<larm_f> value“  in the command file