### PR TITLE
add ASan ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         compiler: ["gcc", "clang++"]
         generator: ["make", "ninja"]
-    name: Ubuntu compile.sh - ${{ matrix.compiler }} - ${{ matrix.generator }}
+    name: "Ubuntu compile.sh :: ${{ matrix.compiler }} :: ${{ matrix.generator }}"
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get update -yy && sudo apt-get install -yy ninja-build
@@ -31,9 +31,16 @@ jobs:
         include:
           - compiler: gcc
             defines: "CC=gcc CXX=g++"
+            build_type: "Release"
           - compiler: clang
             defines: "CC=clang CXX=clang++"
-    name: Ubuntu CMake - ${{ matrix.compiler }} - ninja - system ccfits cfitsio
+            build_type: "Release"
+          - compiler: clang
+            defines: "CC=clang CXX=clang++"
+            build_type: "Debug"
+            exe_linker_flags: "-fsanitize=address"
+            cxx_flags: "-fsanitize=address"
+    name: "Ubuntu :: ${{ matrix.compiler }} :: ${{ matrix.build_type }} :: ${{ matrix.cxx_flags }} :: system ccfits cfitsio"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -41,12 +48,12 @@ jobs:
       - run: |
           mkdir build
           cd build
-          ${{ matrix.defines }} cmake ../src -DCMAKE_BUILD_TYPE=Release -GNinja
+          ${{ matrix.defines }} cmake ../src -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_EXE_LINKER_FLAGS=${{ matrix.exe_linker_flags }} -DCMAKE_CXX_FLAGS=${{ matrix.cxx_flags }}
           ninja
           ninja test
       - run: ./ci/test.sh ./build/polaris projects
   macos-cmake-llvm:
-    name: MacOS CMake llvm + system ccfits cfitsio
+    name: "MacOS :: llvm :: system ccfits cfitsio"
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3

--- a/src/Cylindrical.h
+++ b/src/Cylindrical.h
@@ -202,6 +202,7 @@ class CGridCylindrical : public CGridBasic
                 delete[] grid_cells[i_r];
                 grid_cells[i_r] = 0;
             }
+            delete[] grid_cells;
         }
 
         if(center_cells != 0)
@@ -211,6 +212,7 @@ class CGridCylindrical : public CGridBasic
                 delete center_cells[i_z];
                 center_cells[i_z] = 0;
             }
+            delete[] center_cells;
         }
 
         if(cell_list != 0)

--- a/src/Dust.cpp
+++ b/src/Dust.cpp
@@ -1075,6 +1075,9 @@ bool CDustComponent::readDustRefractiveIndexFile(parameters & param,
                 Qsca2[a][w] = Qsca1[a][w];
                 Qcirc[a][w] = 0;
 
+                if(scat_theta[a][w] != 0){
+                    delete[] scat_theta[a][w];
+                }
                 scat_theta[a][w] = new double[nr_or_scat_theta_final];
 
                 for(uint inc = 0; inc < nr_of_incident_angles; inc++)

--- a/src/Dust.h
+++ b/src/Dust.h
@@ -2185,11 +2185,27 @@ class CDustComponent
 
     void SetNrOfScatTheta(uint ** nr_of_scat_theta_tmp)
     {
+        if(nr_of_scat_theta != 0)
+        {
+            for(uint a = 0; a < nr_of_dust_species; a++)
+                delete[] nr_of_scat_theta[a];
+            delete[] nr_of_scat_theta;
+        }
         nr_of_scat_theta = nr_of_scat_theta_tmp;
     }
 
     void SetScatTheta(double *** scat_theta_tmp)
     {
+        if(scat_theta != 0)
+        {
+            for(uint a = 0; a < nr_of_dust_species; a++)
+            {
+                for(uint w = 0; w < nr_of_wavelength; w++)
+                    delete[] scat_theta[a][w];
+                delete[] scat_theta[a];
+            }
+            delete[] scat_theta;
+        }
         scat_theta = scat_theta_tmp;
     }
 


### PR DESCRIPTION
- add a Debug build to the CI config with ASan enabled
- AddressSanitizer (ASan) is a memory error detector
- see https://github.com/google/sanitizers/wiki/AddressSanitizer

fix memory leaks found by running ci/test.sh with ASan

- `~CGridCylindrical()`
  - add mising `delete[]` for `grid_cells`, `center_cells`
- `CDustComponent::SetScatTheta`
  - delete any existing allocation before re-assigning `scat_theta`
- `CDustComponent::SetNrOfScatTheta`
  - delete any existing allocation before re-assigning `nr_of_scat_theta`
- `readDustRefractiveIndexFile`
  - delete any existing allocation before allocating a new `scat_theta[a][w]` element
